### PR TITLE
Improve header navigation UX and add local preview steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
-# Workspace
+# Immersion Education Partners Site
+
+Astro marketing site for Immersion Education Partners.
+
+## What was improved
+
+- Added smarter header behavior:
+  - closes the mobile menu when you click outside it
+  - highlights active home-page sections (`Services`, `Expertise`) while scrolling
+- Kept existing keyboard support (`Esc` closes the menu) and improved navigation feedback.
+
+## Local development
+
+### 1) Install dependencies
+
+```bash
+npm install
+```
+
+### 2) Run the site in development mode
+
+```bash
+npm run dev
+```
+
+Then open the URL shown in your terminal (typically `http://localhost:4321`).
+
+### 3) Build a production bundle
+
+```bash
+npm run build
+```
+
+### 4) Preview the production build locally
+
+```bash
+npm run preview
+```
+
+Then open the preview URL printed in the terminal.
+
+## Where to see the improvements
+
+1. Start dev server with `npm run dev`.
+2. Open the home page.
+3. Resize to mobile width and open the menu:
+   - click outside the menu to see it close automatically.
+4. On desktop/mobile home page, scroll through sections:
+   - nav links for section anchors are now highlighted as you move through the page.

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -147,10 +147,14 @@ const currentPath = Astro.url.pathname;
 
   .nav-desktop a:hover { color: var(--brand-gold); }
 
-  .nav-desktop a[aria-current="page"] {
+  .nav-desktop a[aria-current="page"],
+  .nav-desktop a[aria-current="location"],
+  .nav-desktop a.is-active {
     color: var(--brand-gold);
   }
-  .nav-desktop a[aria-current="page"]::after {
+  .nav-desktop a[aria-current="page"]::after,
+  .nav-desktop a[aria-current="location"]::after,
+  .nav-desktop a.is-active::after {
     content: '';
     position: absolute;
     left: 0;
@@ -210,6 +214,10 @@ const currentPath = Astro.url.pathname;
     font-weight: 600;
     font-size: 1.125rem;
     border-bottom: 1px solid var(--border-light);
+  }
+  .mobile-nav a[aria-current="location"],
+  .mobile-nav a.is-active {
+    color: var(--brand-gold);
   }
   .mobile-nav a.mobile-cta {
     background: var(--brand-gold);

--- a/src/scripts/header.ts
+++ b/src/scripts/header.ts
@@ -44,6 +44,49 @@ function initHeader() {
   document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape' && panel.classList.contains('open')) close();
   });
+
+  document.addEventListener('click', (e) => {
+    if (!panel.classList.contains('open')) return;
+    const target = e.target as Node;
+    if (!panel.contains(target) && !toggle.contains(target)) close();
+  });
+
+  // Scrollspy for same-page hash links on the home page.
+  const navLinks = document.querySelectorAll<HTMLAnchorElement>(
+    '.nav-desktop a[href^="/#"], .mobile-nav a[href^="/#"]'
+  );
+  const sections = Array.from(navLinks)
+    .map((link) => link.getAttribute('href')?.replace('/#', ''))
+    .filter((id): id is string => Boolean(id))
+    .map((id) => document.getElementById(id))
+    .filter((section): section is HTMLElement => Boolean(section));
+
+  if (window.location.pathname === '/' && sections.length > 0) {
+    const setActive = (id: string) => {
+      navLinks.forEach((link) => {
+        const href = link.getAttribute('href');
+        const active = href === `/#${id}`;
+        link.classList.toggle('is-active', active);
+        if (active) link.setAttribute('aria-current', 'location');
+        else link.removeAttribute('aria-current');
+      });
+    };
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((entry) => entry.isIntersecting)
+          .sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
+        if (visible) setActive(visible.target.id);
+      },
+      {
+        rootMargin: '-35% 0px -55% 0px',
+        threshold: [0.15, 0.35, 0.6],
+      }
+    );
+
+    sections.forEach((section) => observer.observe(section));
+  }
 }
 
 if (document.readyState === 'loading') {


### PR DESCRIPTION
### Motivation
- Improve the header/navigation user experience by making the mobile menu easier to dismiss and giving clear visual feedback for in-page section links on the home page.
- Make it straightforward for maintainers to run and preview the site locally by adding concise dev/build/preview instructions.

### Description
- Added an outside-click handler and a hash-link scrollspy to `src/scripts/header.ts` so the mobile panel closes when clicking outside and home-page anchors (`/#services`, `/#expertise`, etc.) are highlighted while scrolling.
- Updated `src/components/Header.astro` styles to support `.is-active` and `aria-current="location"` states for both desktop and mobile nav links so active sections are visibly highlighted.
- Expanded `README.md` with step-by-step instructions for `npm install`, `npm run dev`, `npm run build`, and `npm run preview`, plus verification steps to see the new behaviors.

### Testing
- Ran `npm install` which completed successfully without errors.
- Ran `npm run build` which completed successfully and produced the static `dist/` output (5 pages built).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e288ad780083328516573753c45b1d)